### PR TITLE
Add missing keyword identifier to keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -169,7 +169,7 @@ getTotalEngineHours	KEYWORD2
 getTotalEngineRevolutions	KEYWORD2
 
 
-refresh
+refresh	KEYWORD2
 getNavBasedSpeed	KEYWORD2
 getEngineAirInletPressure	KEYWORD2
 getEngineExhaustGasTemp	KEYWORD2


### PR DESCRIPTION
The refresh keyword was missing its identifier, causing it to not be highlighted by the Arduino IDE.